### PR TITLE
fix: cdk8s app

### DIFF
--- a/iac/cdk8s.yaml
+++ b/iac/cdk8s.yaml
@@ -1,4 +1,4 @@
-app: poetry run labcli k8s synth
+app: poetry run labcli k8s synth --config-file -
 language: python
 imports:
   - k8s@1.29.0


### PR DESCRIPTION
- updates the `app` in `cdk8s.yaml` to use config from stdin after #7 