### PR TITLE
feat: ingress-nginx

### DIFF
--- a/iac/lab/charts/__init__.py
+++ b/iac/lab/charts/__init__.py
@@ -1,3 +1,7 @@
+from lab.charts.ingress_nginx import IngressNginx
 from lab.charts.tailscale import Tailscale
 
-__all__ = [Tailscale]
+__all__ = [
+    IngressNginx,
+    Tailscale,
+]

--- a/iac/lab/charts/ingress_nginx.py
+++ b/iac/lab/charts/ingress_nginx.py
@@ -1,0 +1,55 @@
+from cdk8s import Chart
+from constructs import Construct
+
+from lab.libs.config import IngressConfig
+from lab.libs.exceptions import LabError
+from lab.libs.k8s.include import Include
+from lab.libs.k8s.api_object import patch_obj
+
+
+class IngressNginx(Chart):
+    VERSION = "1.10.1"
+
+    INGRESS_CLASS_NAME = "nginx"
+
+    MANIFEST_URL = f"https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v{VERSION}/deploy/static/provider/cloud/deploy.yaml"
+
+    def __init__(self, scope: Construct, id_: str, config: IngressConfig):
+        super().__init__(scope, id_)
+
+        ing = Include(
+            self,
+            "ingress-nginx",
+            url=IngressNginx.MANIFEST_URL,
+        )
+
+        ##
+        ## Patch Service
+        ##
+        if not (
+            svc := ing.find_object(kind="Service", name="ingress-nginx-controller")
+        ):
+            raise LabError(
+                "could not find service/ingress-nginx-controller in ingress-nginx manifest"
+            )
+
+        patch_obj(
+            svc,
+            "/metadata/annotations",
+            {
+                "oci.oraclecloud.com/load-balancer-type": "nlb",
+                "oci-network-load-balancer.oraclecloud.com/oci-network-security-groups": config.oci_public_load_balancer_nsg_ocid,
+            },
+        )
+
+        ##
+        ## Patch ConfigMap
+        ##
+        if not (
+            cfg := ing.find_object(kind="Configmap", name="ingress-nginx-controller")
+        ):
+            raise LabError(
+                "could not find configmap/ingress-nginx-controller in ingress-nginx manifest"
+            )
+
+        patch_obj(cfg, "/data/allow-snippet-annotations", "true")

--- a/iac/lab/cli/k8s.py
+++ b/iac/lab/cli/k8s.py
@@ -4,7 +4,7 @@ from rich import print
 import typer
 from lab.libs.cli import make_typer
 
-from lab.charts import Tailscale
+from lab.charts import IngressNginx, Tailscale
 from lab.libs.config import parse_config
 from lab.libs.exceptions import ConfigError
 
@@ -23,6 +23,14 @@ def synth(config_file: Annotated[typer.FileText, typer.Option()]) -> None:
         print(f"[red]{e}[/red]")
         raise typer.Exit(1) from e
 
+    ##
+    ## Cluster Services
+    ##
+    IngressNginx(app, "ingress-nginx", config.ingress)
+
+    ##
+    ## Apps
+    ##
     Tailscale(app, "tailscale", config=config.tailscale)
 
     app.synth()

--- a/iac/lab/constructs/k8s_cluster.py
+++ b/iac/lab/constructs/k8s_cluster.py
@@ -24,6 +24,21 @@ class KubernetesCluster(Construct):
     ):
         super().__init__(scope, id_)
 
+        public_load_balancer_rules = {
+            "Allow TCP ingress to public load balancers for HTTPS traffic from anywhere": {
+                "protocol": 6,
+                "port": 443,
+                "source": "0.0.0.0/0",
+                "source_type": "CIDR_BLOCK",
+            },
+            "Allow TCP ingress to public load balancers for HTTP traffic from anywhere": {
+                "protocol": 6,
+                "port": 80,
+                "source": "0.0.0.0/0",
+                "source_type": "CIDR_BLOCK",
+            },
+        }
+
         # module pinned below < 5.1.1 to work around bug disabling operator
         # where subnets and security groups are still created
         Oke(
@@ -46,6 +61,7 @@ class KubernetesCluster(Construct):
                     "boot_volume_size": 50,
                 },
             },
+            allow_rules_public_lb=public_load_balancer_rules,
             worker_image_type="custom",
             worker_image_id=KubernetesCluster.PINNED_WORKER_IMAGE,
             providers=[

--- a/iac/lab/libs/config.py
+++ b/iac/lab/libs/config.py
@@ -16,8 +16,13 @@ class TailscaleConfig(BaseModel):
     cluster_api_proxy: Optional[TailscaleClusterApiProxy] = None
 
 
+class IngressConfig(BaseModel):
+    oci_public_load_balancer_nsg_ocid: str
+
+
 class Config(BaseModel):
     tailscale: TailscaleConfig
+    ingress: IngressConfig
 
 
 def parse_config(raw_config: IO) -> Config:

--- a/iac/tests/charts/test_ingress_nginx.py
+++ b/iac/tests/charts/test_ingress_nginx.py
@@ -1,0 +1,37 @@
+from collections.abc import Generator
+from typing import Any
+from lab.charts.ingress_nginx import IngressNginx
+import pytest
+import cdk8s
+
+from lab.libs.config import IngressConfig
+from tests.utils import get_resource
+
+
+NSG_OCID = "ocid"
+
+
+class TestIngressNginx:
+    @pytest.fixture(scope="class")
+    def chart(self) -> Generator[list[Any], None, None]:
+        yield IngressNginx(
+            cdk8s.Testing.app(),
+            "ingress-nginx",
+            config=IngressConfig(
+                oci_public_load_balancer_nsg_ocid=NSG_OCID,
+            ),
+        ).to_json()
+
+    def test_includes_deployment(self, chart: list[Any]) -> None:
+        assert get_resource(chart, "Deployment", "ingress-nginx-controller")
+
+    def test_service_uses_nlb(self, chart: list[Any]) -> None:
+        svc = get_resource(chart, "Service", "ingress-nginx-controller")
+        assert {
+            "oci.oraclecloud.com/load-balancer-type": "nlb",
+            "oci-network-load-balancer.oraclecloud.com/oci-network-security-groups": NSG_OCID,
+        } == svc["metadata"]["annotations"]
+
+    def test_snippets_are_enabled(self, chart: list[Any]) -> None:
+        cfg = get_resource(chart, "ConfigMap", "ingress-nginx-controller")
+        assert bool(cfg["data"]["allow-snippet-annotations"])


### PR DESCRIPTION
- adds `ingress-nginx`
  - configures as an OCI Network Load Balancer
- creates NSG rules to allow traffic to public load balancer ports 80/443