### PR TITLE
chore: use in-project poetry venv

### DIFF
--- a/iac/poetry.toml
+++ b/iac/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
- store the poetry virtualenv in the project directory for better discoverability by tooling

see:
> Contained in a directory, conventionally either named venv or .venv in the project directory, [...] [[source]](https://docs.python.org/3/library/venv.html)
