### PR TITLE
Brian/ingress nginx 1.12.1

### DIFF
--- a/iac/lab/charts/ingress_nginx.py
+++ b/iac/lab/charts/ingress_nginx.py
@@ -34,9 +34,7 @@ class IngressNginx(Chart):
             )
 
         if svc.to_json().get("metadata", {}).get("annotations"):
-            raise LabError(
-                "Service has annotations, may be overriding default values"
-            )
+            raise LabError("Service has annotations, may be overriding default values")
 
         patch_obj(
             svc,
@@ -58,12 +56,14 @@ class IngressNginx(Chart):
             )
 
         if cfg.to_json().get("data"):
-            raise LabError(
-                "ConfigMap is not empty, may be overriding default values"
-            )
+            raise LabError("ConfigMap is not empty, may be overriding default values")
 
-        patch_obj(cfg, "/data", {
-            "allow-snippet-annotations": "true",
-            # we trust the users creating Ingress objects
-            "annotations-risk-level": "Critical",
-        })
+        patch_obj(
+            cfg,
+            "/data",
+            {
+                "allow-snippet-annotations": "true",
+                # we trust the users creating Ingress objects
+                "annotations-risk-level": "Critical",
+            },
+        )

--- a/iac/tests/charts/test_ingress_nginx.py
+++ b/iac/tests/charts/test_ingress_nginx.py
@@ -1,15 +1,18 @@
 from collections.abc import Generator
 from typing import Any
+from unittest.mock import Mock, patch
 from lab.charts.ingress_nginx import IngressNginx
 import pytest
 import cdk8s
 
 from lab.libs.config import IngressConfig
+from lab.libs.exceptions import LabError
 from tests.utils import get_resource
 
 
-NSG_OCID = "ocid"
-
+CONFIG = IngressConfig(
+    oci_public_load_balancer_nsg_ocid="ocid",
+)
 
 class TestIngressNginx:
     @pytest.fixture(scope="class")
@@ -17,9 +20,7 @@ class TestIngressNginx:
         yield IngressNginx(
             cdk8s.Testing.app(),
             "ingress-nginx",
-            config=IngressConfig(
-                oci_public_load_balancer_nsg_ocid=NSG_OCID,
-            ),
+            config=CONFIG,
         ).to_json()
 
     def test_includes_deployment(self, chart: list[Any]) -> None:
@@ -29,9 +30,38 @@ class TestIngressNginx:
         svc = get_resource(chart, "Service", "ingress-nginx-controller")
         assert {
             "oci.oraclecloud.com/load-balancer-type": "nlb",
-            "oci-network-load-balancer.oraclecloud.com/oci-network-security-groups": NSG_OCID,
+            "oci-network-load-balancer.oraclecloud.com/oci-network-security-groups": CONFIG.oci_public_load_balancer_nsg_ocid,
         } == svc["metadata"]["annotations"]
 
     def test_snippets_are_enabled(self, chart: list[Any]) -> None:
         cfg = get_resource(chart, "ConfigMap", "ingress-nginx-controller")
         assert bool(cfg["data"]["allow-snippet-annotations"])
+        assert "Critical" == cfg["data"]["annotations-risk-level"]
+
+    @patch("cdk8s.ApiObject.to_json")
+    def test_cannot_override_default_service_annotations(self, mocked_to_json: Mock) -> None:
+        mocked_to_json.return_value = {
+            "metadata": {
+                "annotations": {"foo": "bar"},
+            }
+        }
+
+        with pytest.raises(LabError, match="Service has annotations"):
+            IngressNginx(
+                cdk8s.Testing.app(),
+                "ingress-nginx",
+                config=CONFIG,
+            )
+
+    @patch("cdk8s.ApiObject.to_json")
+    def test_cannot_override_default_configmap_data(self, mocked_to_json: Mock) -> None:
+        mocked_to_json.return_value = {
+            "data": {"foo": "bar"},
+        }
+
+        with pytest.raises(LabError, match="ConfigMap is not empty"):
+            IngressNginx(
+                cdk8s.Testing.app(),
+                "ingress-nginx",
+                config=CONFIG,
+            )

--- a/iac/tests/charts/test_ingress_nginx.py
+++ b/iac/tests/charts/test_ingress_nginx.py
@@ -14,6 +14,7 @@ CONFIG = IngressConfig(
     oci_public_load_balancer_nsg_ocid="ocid",
 )
 
+
 class TestIngressNginx:
     @pytest.fixture(scope="class")
     def chart(self) -> Generator[list[Any], None, None]:
@@ -39,7 +40,9 @@ class TestIngressNginx:
         assert "Critical" == cfg["data"]["annotations-risk-level"]
 
     @patch("cdk8s.ApiObject.to_json")
-    def test_cannot_override_default_service_annotations(self, mocked_to_json: Mock) -> None:
+    def test_cannot_override_default_service_annotations(
+        self, mocked_to_json: Mock
+    ) -> None:
         mocked_to_json.return_value = {
             "metadata": {
                 "annotations": {"foo": "bar"},


### PR DESCRIPTION
* update `ingress-nginx` to 1.12
* raise allowable annotation risk level to Critical, since the new default is High (and we use snippet annotations, which are [a Critical risk](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations-risk/))
* add tests to ensure we don't override any existing data when we use JSON patches