### PR TITLE
chore: update vaultwarden to 1.35.4

### DIFF
--- a/iac/lab/charts/bitwarden.py
+++ b/iac/lab/charts/bitwarden.py
@@ -7,7 +7,7 @@ from lab.libs.config import BitwardenConfig
 
 
 class Bitwarden(Chart):
-    VERSION = "1.34.1"
+    VERSION = "1.35.4"
 
     def __init__(
         self,

--- a/iac/lab/charts/bitwarden.py
+++ b/iac/lab/charts/bitwarden.py
@@ -69,10 +69,7 @@ class Bitwarden(Chart):
         ## Deployment
         ##
         deployment = kplus.Deployment(
-            self,
-            id_,
-            replicas=1,
-            strategy=kplus.DeploymentStrategy.recreate()
+            self, id_, replicas=1, strategy=kplus.DeploymentStrategy.recreate()
         )
 
         main_container = deployment.add_container(

--- a/iac/lab/charts/bitwarden.py
+++ b/iac/lab/charts/bitwarden.py
@@ -50,7 +50,7 @@ class Bitwarden(Chart):
                 "SMTP_FROM": config.smtp.from_email,
                 "SMTP_FROM_NAME": config.smtp.from_name,
                 "SMTP_PORT": str(config.smtp.port),
-                "SMTP_EXPLICIT_TLS": str(config.smtp.use_explicit_tls).lower(),
+                "SMTP_SECURITY": config.smtp.security,
                 "SMTP_USERNAME": config.smtp.username,
             },
         )
@@ -72,6 +72,7 @@ class Bitwarden(Chart):
             self,
             id_,
             replicas=1,
+            strategy=kplus.DeploymentStrategy.recreate()
         )
 
         main_container = deployment.add_container(

--- a/iac/lab/libs/config.py
+++ b/iac/lab/libs/config.py
@@ -1,5 +1,5 @@
 from ipaddress import IPv4Network
-from typing import IO, Optional
+from typing import IO, Literal, Optional
 from pydantic import BaseModel, ValidationError, SecretStr
 
 from lab.libs.exceptions import ConfigError
@@ -37,7 +37,7 @@ class BitwardenSmtpConfig(BaseModel):
     port: int
     username: str
     password: SecretStr
-    use_explicit_tls: bool = True
+    security: Literal["starttls", "off", "force_tls"]
     from_email: str
     from_name: str
 

--- a/iac/tests/charts/test_bitwarden.py
+++ b/iac/tests/charts/test_bitwarden.py
@@ -23,7 +23,7 @@ CONFIG = BitwardenConfig(
         password=SecretStr("example-smtp-pass"),
         from_email="admin@example.com",
         from_name="Example Org",
-        use_explicit_tls=True,
+        security="force_tls",
     ),
 )
 
@@ -64,7 +64,7 @@ class TestBitwarden:
             "INVITATION_ORG_NAME": CONFIG.organization_name,
             "SHOW_PASSWORD_HINT": "false",
             "SIGNUPS_ALLOWED": "false",
-            "SMTP_EXPLICIT_TLS": "true" if CONFIG.smtp.use_explicit_tls else "false",
+            "SMTP_SECURITY": CONFIG.smtp.security,
             "SMTP_FROM": CONFIG.smtp.from_email,
             "SMTP_FROM_NAME": CONFIG.smtp.from_name,
             "SMTP_HOST": CONFIG.smtp.host,


### PR DESCRIPTION
- upgrade vaultwarden to 1.35.4
- replace deprecated `SMTP_EXPLICIT_TLS` with `SMTP_SECURITY`